### PR TITLE
fix enumTags parsing for tileset def

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -131,7 +131,7 @@ const LdtkTilesetDefinition = z.object({
         tileId: z.number()
     })),
     embedAtlas: z.string().nullable(),
-    enumsTags: z.optional(z.array(z.object({
+    enumTags: z.optional(z.array(z.object({
         enumValueId: z.string(),
         tileIds: z.array(z.number())
     }))),


### PR DESCRIPTION
Fixes `enumTags` not being parsed from the ldtk tileset def