### PR TITLE
fix: wrong entity factory being used

### DIFF
--- a/src/ldtk-resource.ts
+++ b/src/ldtk-resource.ts
@@ -263,10 +263,11 @@ export class LdtkResource implements Loadable<LdtkProjectMetadata> {
 
     registerEntityIdentifierFactory(ldtkEntityIdentifier: string, factory: (props: FactoryProps) => Entity | undefined): void {
         this.factories.set(ldtkEntityIdentifier, factory);
-        if (this.isLoaded()) {
-            for (let entityLayer of this.getEntityLayers()) {
-                entityLayer.runFactory(ldtkEntityIdentifier);
-            }
+    }
+
+    registerEntityIdentifierFactories(factories: Record<string, (props: FactoryProps) => Entity | undefined>): void {
+        for (const key in factories) {
+            this.registerEntityIdentifierFactory(key, factories[key]);
         }
     }
 
@@ -453,6 +454,7 @@ export class LdtkResource implements Loadable<LdtkProjectMetadata> {
     addToScene(scene: Scene, options?: AddToSceneOptions) {
         const { pos, useLevelOffsets } = {pos: vec(0, 0), useLevelOffsets: true, ...options};
 
+        
         for (let [id, level] of this.levels.entries()) {
             if (options?.levelFilter?.length) {
                 if (!options.levelFilter.includes(level.ldtkLevel.identifier)) {
@@ -467,6 +469,7 @@ export class LdtkResource implements Loadable<LdtkProjectMetadata> {
                     }
                     scene.add(layer.tilemap)
                 } else {
+                    layer.runFactories()
                     for (let entity of layer.entities) {
                         const tx = entity.get(TransformComponent);
                         if (tx) {


### PR DESCRIPTION
<!--
Hi, and thanks for contributing to Excalibur!
Before you go any further, please read our contributing guide: https://github.com/excaliburjs/Excalibur/blob/master/.github/CONTRIBUTING.md
especially the "Submitting Changes" section:
https://github.com/excaliburjs/Excalibur/blob/master/.github/CONTRIBUTING.md#submitting-changes
---
A quick summary checklist is included below for convenience:
-->

===:clipboard: PR Checklist :clipboard:===

- [ ] :pushpin: issue exists in github for these changes
- [ ] :microscope: existing tests still pass
- [x] :see_no_evil: code conforms to the [style guide](https://github.com/excaliburjs/Excalibur/blob/master/STYLEGUIDE.md)
- [ ] :triangular_ruler: new tests written and passing / old tests updated with new scenario(s)
- [ ] :page_facing_up: changelog entry added (or not needed)

==================

<!-- If you're closing an issue with this pull request, or contributing a significant change, please include your changes in the appropriate section of CHANGELOG.md as outlined in https://github.com/excaliburjs/Excalibur/blob/master/.github/CONTRIBUTING.md#creating-a-pull-request. -->

<!--Please format your pull request title according to our commit message styleguide: https://github.com/excaliburjs/Excalibur/blob/master/.github/CONTRIBUTING.md#commit-messages -->

<!-- Thanks again! -->

<!--------------------------------------------------------------------------------------------->

## Changes:

- fixes bug where wrong entity factory would be used under certain conditions
- adds `LdtkResource.registerEntityIdentifierFactories()` method for adding multiple factories
- defers entity factories from running until LDTK resource is added to the scene
