### PR TITLE
[#10] Use prefix to filter for solid int values

### DIFF
--- a/src/intgrid-layer.ts
+++ b/src/intgrid-layer.ts
@@ -38,20 +38,15 @@ export class IntGridLayer {
             });
 
             if (layerMetadata) {
-                const solidValue = layerMetadata.intGridValues.find(val => {
-                    return val?.identifier?.toLocaleLowerCase() === 'solid';
-                });
+                const solidValues = layerMetadata.intGridValues.filter(val => {
+                    return val?.identifier?.toLocaleLowerCase().startsWith('solid');
+                }).map(val => val.value);
 
                 for (let i = 0; i < ldtkLayer.intGridCsv.length; i++) {
                     const xCoord = i % columns;
                     const yCoord = Math.floor(i / columns);
                     const tile = this.tilemap.getTile(xCoord, yCoord);
-                    if (solidValue && ldtkLayer.intGridCsv[i] === solidValue.value) {
-                        tile!.solid = true;
-                    }
-
-                    // TODO might be a mistake to treat 1 as solid if there isn't a labelled solid
-                    if (!solidValue && ldtkLayer.intGridCsv[i] === 1) {
+                    if (solidValues.includes(ldtkLayer.intGridCsv[i])) {
                         tile!.solid = true;
                     }
                 }


### PR DESCRIPTION
- [x] :pushpin: issue exists in github for these changes
- [ ] :microscope: existing tests still pass
- [ ] :see_no_evil: code conforms to the [style guide](https://github.com/excaliburjs/Excalibur/blob/master/STYLEGUIDE.md)
- [ ] :triangular_ruler: new tests written and passing / old tests updated with new scenario(s)
- [ ] :page_facing_up: changelog entry added (or not needed)

Closes #10 

## Changes:

- IntGridValues will now be solid, if its identifier has a prefix of 'solid' instead of an equality comparision.
- Remove fallback if not solid IntValue is present in an IntGridLayer

## Open questions:

- This is a breaking change: if users expect the fallback to work, so they will need to add an identifier with prefix solid
- The documentation has to be adapted. Whats the process for that?